### PR TITLE
feat(scm): GitHub PR delivery + sandboxed code validator

### DIFF
--- a/cmd/sre-agent/main.go
+++ b/cmd/sre-agent/main.go
@@ -27,8 +27,11 @@ import (
 	"github.com/avivl/cloud-sre-agent/internal/llm/gemini"
 	"github.com/avivl/cloud-sre-agent/internal/obs"
 	"github.com/avivl/cloud-sre-agent/internal/pipeline"
+	"github.com/avivl/cloud-sre-agent/internal/scm"
+	"github.com/avivl/cloud-sre-agent/internal/scm/github"
 	"github.com/avivl/cloud-sre-agent/internal/scm/local"
 	"github.com/avivl/cloud-sre-agent/internal/security"
+	"github.com/avivl/cloud-sre-agent/internal/validate"
 )
 
 func main() {
@@ -92,15 +95,24 @@ func run(parent context.Context, cfg config.Config, out io.Writer) error {
 		return fmt.Errorf("build llm provider: %w", err)
 	}
 
-	// Delivery target: local patch directory.
-	target := local.New(cfg.Output.Dir)
+	// Delivery target: local patch directory or a GitHub pull request.
+	target, err := buildTarget(cfg, log)
+	if err != nil {
+		return fmt.Errorf("build delivery target: %w", err)
+	}
 
 	// Sanitizer is the prompt-input scrubber and also the last line of defense
 	// for any error string we log (errors may echo log content / PHI).
 	sanitizer := security.New()
 
-	// Pipeline: sanitizer + noop validator wired through the ports.
-	pipe, err := pipeline.New(provider, sanitizer, target, pipeline.WithLogger(log))
+	// Code validator gating the generated patch before delivery.
+	validator := buildValidator(cfg, log)
+
+	// Pipeline: sanitizer + selected validator wired through the ports.
+	pipe, err := pipeline.New(provider, sanitizer, target,
+		pipeline.WithLogger(log),
+		pipeline.WithValidator(validator),
+	)
 	if err != nil {
 		return fmt.Errorf("build pipeline: %w", err)
 	}
@@ -125,6 +137,8 @@ func run(parent context.Context, cfg config.Config, out io.Writer) error {
 		"model", cfg.LLM.Model,
 		"sources", len(sources),
 		"output_dir", cfg.Output.Dir,
+		"target", target.Name(),
+		"validator", cfg.Validator,
 	)
 
 	return consume(ctx, sources, detector, pipe, sanitizer, log)
@@ -155,6 +169,56 @@ func buildProvider(ctx context.Context, l config.LLMConfig) (*gemini.Provider, e
 		})
 	default:
 		return nil, fmt.Errorf("unsupported llm backend %q", l.Backend)
+	}
+}
+
+// buildTarget selects the delivery target from config. "local" writes patches
+// to the output directory; "github" opens a real pull request, reading its
+// access token from the GITHUB_TOKEN environment variable at wire time — the
+// token is never stored in config and never logged. config.Validate has already
+// enforced that the github target carries owner+repo.
+func buildTarget(cfg config.Config, log *slog.Logger) (scm.PRTarget, error) {
+	switch cfg.Target {
+	case config.TargetLocal:
+		return local.New(cfg.Output.Dir), nil
+	case config.TargetGitHub:
+		token := os.Getenv(config.GitHubTokenEnv)
+		if token == "" {
+			return nil, fmt.Errorf("github target selected but %s is empty", config.GitHubTokenEnv)
+		}
+		t, err := github.New(github.Config{
+			Owner:      cfg.GitHub.Owner,
+			Repo:       cfg.GitHub.Repo,
+			BaseBranch: cfg.GitHub.BaseBranch,
+			Token:      token,
+		})
+		if err != nil {
+			return nil, err
+		}
+		// Token is held only inside the HTTP transport; log non-sensitive routing.
+		log.Info("github delivery target configured",
+			"owner", cfg.GitHub.Owner,
+			"repo", cfg.GitHub.Repo,
+			"base_branch", cfg.GitHub.BaseBranch,
+		)
+		return t, nil
+	default:
+		return nil, fmt.Errorf("unsupported delivery target %q", cfg.Target)
+	}
+}
+
+// buildValidator selects the code validator from config. "none" is the no-op
+// default; "local" gates Go patches with the local toolchain. config.Validate
+// has already rejected unknown values, so the default arm should be unreachable;
+// it falls back to the no-op validator rather than panic.
+func buildValidator(cfg config.Config, log *slog.Logger) pipeline.CodeValidator {
+	switch cfg.Validator {
+	case config.ValidatorLocal:
+		return validate.New(validate.WithLogger(log))
+	case config.ValidatorNone:
+		return pipeline.NoopValidator{}
+	default:
+		return pipeline.NoopValidator{}
 	}
 }
 

--- a/config.yaml
+++ b/config.yaml
@@ -35,6 +35,25 @@ llm:
 output:
   dir: ./out
 
+# Delivery target: where a remediation is delivered.
+#   local  — write the patch and a JSON metadata sidecar under output.dir (default).
+#   github — open a real pull request against the repository below.
+target: local
+
+# GitHub delivery target (used only when target: github). The access token is
+# NEVER stored here — it is read from the GITHUB_TOKEN environment variable at
+# startup and is never logged. owner and repo are required when target: github.
+github:
+  owner: my-org
+  repo: my-repo
+  # Branch PRs target and branch from; defaults to "main".
+  base_branch: main
+
+# Code validator: gates an LLM-generated patch before it is delivered.
+#   none   — accept every patch (default).
+#   local  — validate Go patches with the local toolchain (parse, gofmt, go vet).
+validator: none
+
 log:
   level: info
   format: json

--- a/go.mod
+++ b/go.mod
@@ -6,6 +6,7 @@ require (
 	cloud.google.com/go/pubsub/v2 v2.6.0
 	github.com/GoogleCloudPlatform/opentelemetry-operations-go/exporter/trace v1.33.0
 	github.com/failsafe-go/failsafe-go v0.9.6
+	github.com/google/go-github/v88 v88.0.0
 	github.com/invopop/jsonschema v0.14.0
 	github.com/knadh/koanf/parsers/yaml v1.1.0
 	github.com/knadh/koanf/providers/confmap v1.0.0
@@ -43,6 +44,7 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/go-viper/mapstructure/v2 v2.4.0 // indirect
 	github.com/google/go-cmp v0.7.0 // indirect
+	github.com/google/go-querystring v1.2.0 // indirect
 	github.com/google/s2a-go v0.1.9 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.3.15 // indirect

--- a/go.sum
+++ b/go.sum
@@ -87,8 +87,13 @@ github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMyw
 github.com/google/go-cmp v0.4.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.3/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
 github.com/google/go-cmp v0.7.0 h1:wk8382ETsv4JYUZwIsn6YpYiWiBsYLSJiTsyBybVuN8=
 github.com/google/go-cmp v0.7.0/go.mod h1:pXiqmnSA92OHEEa9HXL2W4E7lf9JzCmGVUdgjX3N/iU=
+github.com/google/go-github/v88 v88.0.0 h1:dZA9IKkPK1eXZj4ypngnpRj5FwdpTv4whix2PrQMP7M=
+github.com/google/go-github/v88 v88.0.0/go.mod h1:rufTDgn2N45wjhukLTyxmvc9nilSp3mr3Rgtt6b1MPw=
+github.com/google/go-querystring v1.2.0 h1:yhqkPbu2/OH+V9BfpCVPZkNmUXhb2gBxJArfhIxNtP0=
+github.com/google/go-querystring v1.2.0/go.mod h1:8IFJqpSRITyJ8QhQ13bmbeMBDfmeEJZD5A0egEOmkqU=
 github.com/google/s2a-go v0.1.9 h1:LGD7gtMgezd8a/Xak7mEWL0PjoTQFvpRudN895yqKW0=
 github.com/google/s2a-go v0.1.9/go.mod h1:YA0Ei2ZQL3acow2O62kdp9UlnvMmU7kA6Eutn0dXayM=
 github.com/google/uuid v1.1.2/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -20,11 +20,14 @@ const EnvPrefix = "SRE_"
 
 // Config is the full, typed agent configuration.
 type Config struct {
-	Sources []SourceConfig `koanf:"sources"`
-	LLM     LLMConfig      `koanf:"llm"`
-	Output  OutputConfig   `koanf:"output"`
-	Log     LogConfig      `koanf:"log"`
-	Tracing TracingConfig  `koanf:"tracing"`
+	Sources   []SourceConfig `koanf:"sources"`
+	LLM       LLMConfig      `koanf:"llm"`
+	Output    OutputConfig   `koanf:"output"`
+	Target    string         `koanf:"target"`
+	Validator string         `koanf:"validator"`
+	GitHub    GitHubConfig   `koanf:"github"`
+	Log       LogConfig      `koanf:"log"`
+	Tracing   TracingConfig  `koanf:"tracing"`
 }
 
 // Source type identifiers.
@@ -98,6 +101,36 @@ type OutputConfig struct {
 	Dir string `koanf:"dir"`
 }
 
+// Delivery target identifiers. "local" writes patches to the output directory;
+// "github" opens a real pull request.
+const (
+	TargetLocal  = "local"
+	TargetGitHub = "github"
+)
+
+// Code validator identifiers. "none" accepts every patch (NoopValidator);
+// "local" gates patches with the local Go toolchain.
+const (
+	ValidatorNone  = "none"
+	ValidatorLocal = "local"
+)
+
+// GitHubTokenEnv is the environment variable the GitHub target reads its access
+// token from at wire time. The token is NEVER stored in config and never logged.
+const GitHubTokenEnv = "GITHUB_TOKEN"
+
+// GitHubConfig configures the GitHub delivery target. The access token is not
+// stored here — it is read from the GitHubTokenEnv environment variable when the
+// target is constructed.
+type GitHubConfig struct {
+	// Owner is the repository owner (user or org). Required for the github target.
+	Owner string `koanf:"owner"`
+	// Repo is the repository name. Required for the github target.
+	Repo string `koanf:"repo"`
+	// BaseBranch is the branch PRs target and branch from; defaults to "main".
+	BaseBranch string `koanf:"base_branch"`
+}
+
 // LogConfig controls observability output.
 type LogConfig struct {
 	// Level is one of debug, info, warn, error.
@@ -118,9 +151,12 @@ func Default() Config {
 			Backend:  BackendVertex,
 			Location: "us-central1",
 		},
-		Output:  OutputConfig{Dir: "./out"},
-		Log:     LogConfig{Level: "info", Format: "json"},
-		Tracing: TracingConfig{Exporter: TracingExporterNone},
+		Output:    OutputConfig{Dir: "./out"},
+		Target:    TargetLocal,
+		Validator: ValidatorNone,
+		GitHub:    GitHubConfig{BaseBranch: "main"},
+		Log:       LogConfig{Level: "info", Format: "json"},
+		Tracing:   TracingConfig{Exporter: TracingExporterNone},
 	}
 }
 
@@ -133,15 +169,18 @@ func Load(path string) (Config, error) {
 	// default (at least one must be configured).
 	d := Default()
 	if err := k.Load(confmap.Provider(map[string]any{
-		"llm.provider":     d.LLM.Provider,
-		"llm.model":        d.LLM.Model,
-		"llm.api_key_env":  d.LLM.APIKeyEnv,
-		"llm.backend":      d.LLM.Backend,
-		"llm.location":     d.LLM.Location,
-		"output.dir":       d.Output.Dir,
-		"log.level":        d.Log.Level,
-		"log.format":       d.Log.Format,
-		"tracing.exporter": d.Tracing.Exporter,
+		"llm.provider":       d.LLM.Provider,
+		"llm.model":          d.LLM.Model,
+		"llm.api_key_env":    d.LLM.APIKeyEnv,
+		"llm.backend":        d.LLM.Backend,
+		"llm.location":       d.LLM.Location,
+		"output.dir":         d.Output.Dir,
+		"target":             d.Target,
+		"validator":          d.Validator,
+		"github.base_branch": d.GitHub.BaseBranch,
+		"log.level":          d.Log.Level,
+		"log.format":         d.Log.Format,
+		"tracing.exporter":   d.Tracing.Exporter,
 	}, "."), nil); err != nil {
 		return Config{}, fmt.Errorf("config: seed defaults: %w", err)
 	}
@@ -193,6 +232,12 @@ func (c Config) Validate() error {
 	if c.Output.Dir == "" {
 		return fmt.Errorf("config: output.dir is required")
 	}
+	if err := c.validateTarget(); err != nil {
+		return err
+	}
+	if err := c.validateValidator(); err != nil {
+		return err
+	}
 	switch c.Log.Format {
 	case "", "json", "text":
 	default:
@@ -202,6 +247,34 @@ func (c Config) Validate() error {
 		return err
 	}
 	return nil
+}
+
+// validateTarget enforces the delivery target selector. "local" is the default
+// and needs nothing; "github" requires owner and repo (the token is read from
+// the environment at wire time, not validated here).
+func (c Config) validateTarget() error {
+	switch c.Target {
+	case TargetLocal:
+		return nil
+	case TargetGitHub:
+		if c.GitHub.Owner == "" || c.GitHub.Repo == "" {
+			return fmt.Errorf("config: target %q requires github.owner and github.repo", c.Target)
+		}
+		return nil
+	default:
+		return fmt.Errorf("config: target %q must be %q or %q", c.Target, TargetLocal, TargetGitHub)
+	}
+}
+
+// validateValidator enforces the code-validator selector: "none" (default) or
+// "local".
+func (c Config) validateValidator() error {
+	switch c.Validator {
+	case ValidatorNone, ValidatorLocal:
+		return nil
+	default:
+		return fmt.Errorf("config: validator %q must be %q or %q", c.Validator, ValidatorNone, ValidatorLocal)
+	}
 }
 
 // validate checks one source's required fields by type.

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -67,8 +67,10 @@ func TestValidate_Backend(t *testing.T) {
 				Provider: "gemini", Model: "m",
 				Backend: BackendVertex, Project: "p", Location: "us-central1",
 			},
-			Output: OutputConfig{Dir: "./out"},
-			Log:    LogConfig{Format: "json"},
+			Output:    OutputConfig{Dir: "./out"},
+			Target:    TargetLocal,
+			Validator: ValidatorNone,
+			Log:       LogConfig{Format: "json"},
 		}
 	}
 
@@ -134,8 +136,10 @@ func TestValidate(t *testing.T) {
 				Provider: "gemini", Model: "m",
 				Backend: BackendVertex, Project: "p", Location: "us-central1",
 			},
-			Output: OutputConfig{Dir: "./out"},
-			Log:    LogConfig{Format: "json"},
+			Output:    OutputConfig{Dir: "./out"},
+			Target:    TargetLocal,
+			Validator: ValidatorNone,
+			Log:       LogConfig{Format: "json"},
 		}
 	}
 	require.NoError(t, base().Validate())
@@ -215,8 +219,10 @@ func TestValidate_PubSubSource(t *testing.T) {
 				Provider: "gemini", Model: "m",
 				Backend: BackendVertex, Project: "p", Location: "us-central1",
 			},
-			Output: OutputConfig{Dir: "./out"},
-			Log:    LogConfig{Format: "json"},
+			Output:    OutputConfig{Dir: "./out"},
+			Target:    TargetLocal,
+			Validator: ValidatorNone,
+			Log:       LogConfig{Format: "json"},
 		}
 	}
 
@@ -238,9 +244,132 @@ func TestValidate_UnknownSourceType(t *testing.T) {
 			Provider: "gemini", Model: "m",
 			Backend: BackendVertex, Project: "p", Location: "us-central1",
 		},
-		Output: OutputConfig{Dir: "./out"},
-		Log:    LogConfig{Format: "json"},
+		Output:    OutputConfig{Dir: "./out"},
+		Target:    TargetLocal,
+		Validator: ValidatorNone,
+		Log:       LogConfig{Format: "json"},
 	}
+	require.Error(t, c.Validate())
+}
+
+func TestLoad_TargetValidatorDefaults(t *testing.T) {
+	p := writeConfig(t, `
+sources:
+  - type: file
+    path: ./x.log
+llm:
+  project: my-gcp-project
+`)
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, TargetLocal, cfg.Target)
+	assert.Equal(t, ValidatorNone, cfg.Validator)
+	assert.Equal(t, "main", cfg.GitHub.BaseBranch)
+}
+
+func TestLoad_GitHubTargetBlock(t *testing.T) {
+	p := writeConfig(t, `
+sources:
+  - type: file
+    path: ./x.log
+llm:
+  project: my-gcp-project
+target: github
+validator: local
+github:
+  owner: my-org
+  repo: my-repo
+  base_branch: develop
+`)
+	cfg, err := Load(p)
+	require.NoError(t, err)
+	assert.Equal(t, TargetGitHub, cfg.Target)
+	assert.Equal(t, ValidatorLocal, cfg.Validator)
+	assert.Equal(t, "my-org", cfg.GitHub.Owner)
+	assert.Equal(t, "my-repo", cfg.GitHub.Repo)
+	assert.Equal(t, "develop", cfg.GitHub.BaseBranch)
+}
+
+func TestValidate_Target(t *testing.T) {
+	base := func() Config {
+		return Config{
+			Sources: []SourceConfig{{Type: "file", Path: "x.log"}},
+			LLM: LLMConfig{
+				Provider: "gemini", Model: "m",
+				Backend: BackendVertex, Project: "p", Location: "us-central1",
+			},
+			Output:    OutputConfig{Dir: "./out"},
+			Target:    TargetLocal,
+			Validator: ValidatorNone,
+			Log:       LogConfig{Format: "json"},
+		}
+	}
+
+	t.Run("local needs no github fields", func(t *testing.T) {
+		require.NoError(t, base().Validate())
+	})
+
+	t.Run("github with owner+repo is valid", func(t *testing.T) {
+		c := base()
+		c.Target = TargetGitHub
+		c.GitHub = GitHubConfig{Owner: "o", Repo: "r"}
+		require.NoError(t, c.Validate())
+	})
+
+	t.Run("github missing owner fails", func(t *testing.T) {
+		c := base()
+		c.Target = TargetGitHub
+		c.GitHub = GitHubConfig{Repo: "r"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("github missing repo fails", func(t *testing.T) {
+		c := base()
+		c.Target = TargetGitHub
+		c.GitHub = GitHubConfig{Owner: "o"}
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("unknown target fails", func(t *testing.T) {
+		c := base()
+		c.Target = "gitlab"
+		require.Error(t, c.Validate())
+	})
+
+	t.Run("empty target fails", func(t *testing.T) {
+		c := base()
+		c.Target = ""
+		require.Error(t, c.Validate())
+	})
+}
+
+func TestValidate_Validator(t *testing.T) {
+	base := func() Config {
+		return Config{
+			Sources: []SourceConfig{{Type: "file", Path: "x.log"}},
+			LLM: LLMConfig{
+				Provider: "gemini", Model: "m",
+				Backend: BackendVertex, Project: "p", Location: "us-central1",
+			},
+			Output:    OutputConfig{Dir: "./out"},
+			Target:    TargetLocal,
+			Validator: ValidatorNone,
+			Log:       LogConfig{Format: "json"},
+		}
+	}
+
+	for _, v := range []string{ValidatorNone, ValidatorLocal} {
+		c := base()
+		c.Validator = v
+		require.NoErrorf(t, c.Validate(), "validator %q should be valid", v)
+	}
+
+	c := base()
+	c.Validator = "sandbox"
+	require.Error(t, c.Validate())
+
+	c = base()
+	c.Validator = ""
 	require.Error(t, c.Validate())
 }
 
@@ -252,8 +381,10 @@ func TestValidate_Tracing(t *testing.T) {
 				Provider: "gemini", Model: "m",
 				Backend: BackendVertex, Project: "p", Location: "us-central1",
 			},
-			Output: OutputConfig{Dir: "./out"},
-			Log:    LogConfig{Format: "json"},
+			Output:    OutputConfig{Dir: "./out"},
+			Target:    TargetLocal,
+			Validator: ValidatorNone,
+			Log:       LogConfig{Format: "json"},
 		}
 	}
 

--- a/internal/obs/obs_test.go
+++ b/internal/obs/obs_test.go
@@ -55,6 +55,8 @@ func TestRedacted(t *testing.T) {
 	// source and error are now sensitive keys.
 	assert.Equal(t, RedactedPlaceholder, Redacted("source", "file").Value.String())
 	assert.Equal(t, RedactedPlaceholder, Redacted("error", "boom for bob@x.com").Value.String())
+	// error_detail is a defense-in-depth backstop key.
+	assert.Equal(t, RedactedPlaceholder, Redacted("error_detail", "derived from err").Value.String())
 	// A non-sensitive key passes through.
 	assert.Equal(t, "us-central1", Redacted("region", "us-central1").Value.String())
 }

--- a/internal/obs/redact.go
+++ b/internal/obs/redact.go
@@ -26,6 +26,10 @@ var sensitiveKeys = map[string]struct{}{
 	"error":  {},
 	"err":    {},
 	"source": {},
+	// error_detail/error_type carry sanitized-but-error-derived strings;
+	// redacting them as well is a defense-in-depth backstop.
+	"error_detail": {},
+	"error_type":   {},
 }
 
 // redactAttr is a slog ReplaceAttr hook that masks the value of any attribute

--- a/internal/scm/github/github.go
+++ b/internal/scm/github/github.go
@@ -1,0 +1,316 @@
+// Package github implements the scm.PRTarget port by delivering a remediation
+// as a real GitHub pull request. Each Deliver call branches off the configured
+// base branch, writes change.Patch as the FULL file body via the Contents API,
+// and opens a PR from the new branch into the base branch.
+//
+// The adapter treats change.Patch as the complete file body (per the port's
+// "full file body" contract for this target), not a unified diff.
+package github
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"regexp"
+	"strings"
+
+	gh "github.com/google/go-github/v88/github"
+
+	"github.com/avivl/cloud-sre-agent/internal/domain"
+	"github.com/avivl/cloud-sre-agent/internal/scm"
+)
+
+// name is the adapter identifier reported by Name and used in logs/metrics.
+const name = "github"
+
+// defaultBaseBranch is used when Config.BaseBranch is empty.
+const defaultBaseBranch = "main"
+
+// branchPrefix namespaces every branch this adapter creates.
+const branchPrefix = "sre-agent/"
+
+// Config configures a GitHubTarget. Token is never logged.
+type Config struct {
+	// Owner is the repository owner (user or org).
+	Owner string
+	// Repo is the repository name.
+	Repo string
+	// BaseBranch is the branch PRs target and branch from; defaults to "main".
+	BaseBranch string
+	// Token is the GitHub access token used for authentication.
+	Token string
+	// BaseURL overrides the GitHub API base URL (e.g. an httptest server in
+	// tests, or a GitHub Enterprise host). Empty means public github.com.
+	BaseURL string
+	// HTTPClient overrides the transport used to reach GitHub. When nil, an
+	// oauth2 client carrying Token is used.
+	HTTPClient *http.Client
+}
+
+// GitHubTarget delivers a Change as a GitHub pull request. It implements
+// scm.PRTarget. Construct with New or NewWithClient.
+//
+//nolint:revive // "GitHub" stutter with the package name is the clearest name for the exported type.
+type GitHubTarget struct {
+	client     *gh.Client
+	owner      string
+	repo       string
+	baseBranch string
+}
+
+// New builds a GitHubTarget from cfg, constructing a *github.Client wired with
+// the configured token and (optional) base URL. The token is held only inside
+// the HTTP transport and is never logged.
+func New(cfg Config) (*GitHubTarget, error) {
+	if strings.TrimSpace(cfg.Owner) == "" {
+		return nil, fmt.Errorf("%s: Owner is required", name)
+	}
+	if strings.TrimSpace(cfg.Repo) == "" {
+		return nil, fmt.Errorf("%s: Repo is required", name)
+	}
+
+	opts := []gh.ClientOptionsFunc{gh.WithAuthToken(cfg.Token)}
+	if cfg.HTTPClient != nil {
+		opts = append(opts, gh.WithHTTPClient(cfg.HTTPClient))
+	}
+	if strings.TrimSpace(cfg.BaseURL) != "" {
+		// Same host serves API and uploads in tests / enterprise single-host setups.
+		opts = append(opts, gh.WithEnterpriseURLs(cfg.BaseURL, cfg.BaseURL))
+	}
+
+	client, err := gh.NewClient(opts...)
+	if err != nil {
+		return nil, fmt.Errorf("%s: build client: %w", name, err)
+	}
+
+	return NewWithClient(client, cfg.Owner, cfg.Repo, cfg.BaseBranch), nil
+}
+
+// NewWithClient builds a GitHubTarget from an already-constructed *github.Client.
+// This is the test seam: callers point the client at an httptest.Server. An
+// empty baseBranch defaults to "main".
+func NewWithClient(client *gh.Client, owner, repo, baseBranch string) *GitHubTarget {
+	if strings.TrimSpace(baseBranch) == "" {
+		baseBranch = defaultBaseBranch
+	}
+	return &GitHubTarget{
+		client:     client,
+		owner:      owner,
+		repo:       repo,
+		baseBranch: baseBranch,
+	}
+}
+
+// Name identifies the adapter.
+func (t *GitHubTarget) Name() string { return name }
+
+// Deliver opens a pull request carrying change.Patch as the full body of
+// change.FilePath:
+//
+//  1. read the base branch ref to find its commit SHA;
+//  2. create a new branch ref off that SHA (tolerating an already-exists branch);
+//  3. create-or-update change.FilePath via the Contents API with the full body;
+//  4. open a PR from the new branch into the base branch.
+//
+// It returns scm.Ref{ID: PR number, URL: PR html_url}.
+func (t *GitHubTarget) Deliver(ctx context.Context, change scm.Change) (scm.Ref, error) {
+	if strings.TrimSpace(change.FilePath) == "" {
+		return scm.Ref{}, fmt.Errorf("%s: change.FilePath is required", name)
+	}
+	if change.Patch == "" {
+		return scm.Ref{}, fmt.Errorf("%s: change.Patch is empty", name)
+	}
+
+	// (1) Base branch commit SHA.
+	baseRef, _, err := t.client.Git.GetRef(ctx, t.owner, t.repo, "refs/heads/"+t.baseBranch)
+	if err != nil {
+		return scm.Ref{}, fmt.Errorf("%s: get base ref %q: %w", name, t.baseBranch, err)
+	}
+	baseSHA := baseRef.GetObject().GetSHA()
+	if baseSHA == "" {
+		return scm.Ref{}, fmt.Errorf("%s: base ref %q has no commit SHA", name, t.baseBranch)
+	}
+
+	// (2) New branch off the base SHA. Tolerate "already exists" (HTTP 422): on a
+	// re-run the branch lingers from a prior delivery, so force-reset it to the
+	// freshly-resolved base SHA. Otherwise the PR would sit on a stale tree
+	// rather than current base.
+	branch := branchName(change)
+	newRef := "refs/heads/" + branch
+	if _, _, err = t.client.Git.CreateRef(ctx, t.owner, t.repo, gh.CreateRef{
+		Ref: newRef,
+		SHA: baseSHA,
+	}); err != nil {
+		if !isAlreadyExists(err) {
+			return scm.Ref{}, fmt.Errorf("%s: create branch %q: %w", name, branch, err)
+		}
+		if _, _, err = t.client.Git.UpdateRef(ctx, t.owner, t.repo, newRef, gh.UpdateRef{
+			SHA:   baseSHA,
+			Force: gh.Ptr(true),
+		}); err != nil {
+			return scm.Ref{}, fmt.Errorf("%s: reset branch %q to base: %w", name, branch, err)
+		}
+	}
+
+	// (3) Create-or-update the file on the new branch with the full body.
+	if err = t.putFile(ctx, branch, change); err != nil {
+		return scm.Ref{}, err
+	}
+
+	// (4) Open the PR. On a re-run an open PR for this head branch may already
+	// exist; GitHub answers Create with a 422 "A pull request already exists".
+	// Treat that as success by resolving and returning the existing PR.
+	pr, _, err := t.client.PullRequests.Create(ctx, t.owner, t.repo, &gh.NewPullRequest{
+		Title: gh.Ptr(prTitle(change)),
+		Head:  gh.Ptr(branch),
+		Base:  gh.Ptr(t.baseBranch),
+		Body:  gh.Ptr(change.Description),
+	})
+	if err != nil {
+		if isAlreadyExists(err) {
+			return t.existingPR(ctx, branch)
+		}
+		return scm.Ref{}, fmt.Errorf("%s: open pull request: %w", name, err)
+	}
+
+	return prRef(pr), nil
+}
+
+// existingPR resolves the open PR whose head is branch and returns its ref. It
+// is the recovery path when PullRequests.Create reports the PR already exists.
+func (t *GitHubTarget) existingPR(ctx context.Context, branch string) (scm.Ref, error) {
+	prs, _, err := t.client.PullRequests.List(ctx, t.owner, t.repo, &gh.PullRequestListOptions{
+		State: "open",
+		Head:  t.owner + ":" + branch,
+	})
+	if err != nil {
+		return scm.Ref{}, fmt.Errorf("%s: list existing pull requests for %q: %w", name, branch, err)
+	}
+	if len(prs) == 0 {
+		return scm.Ref{}, fmt.Errorf("%s: pull request reported as existing for %q but none found", name, branch)
+	}
+	return prRef(prs[0]), nil
+}
+
+// prRef projects a PR into the scm.Ref returned by Deliver.
+func prRef(pr *gh.PullRequest) scm.Ref {
+	return scm.Ref{
+		ID:  fmt.Sprintf("%d", pr.GetNumber()),
+		URL: pr.GetHTMLURL(),
+	}
+}
+
+// putFile creates change.FilePath, or updates it (supplying the current blob
+// SHA) when it already exists on the branch. change.Patch is the full body.
+func (t *GitHubTarget) putFile(ctx context.Context, branch string, change scm.Change) error {
+	opts := &gh.RepositoryContentFileOptions{
+		Message: gh.Ptr(commitMessage(change)),
+		Content: []byte(change.Patch),
+		Branch:  gh.Ptr(branch),
+	}
+
+	existing, _, _, err := t.client.Repositories.GetContents(
+		ctx, t.owner, t.repo, change.FilePath,
+		&gh.RepositoryContentGetOptions{Ref: branch},
+	)
+	switch {
+	case err == nil && existing == nil:
+		// GetContents returns a nil file entry (with no error) when the path
+		// resolves to a directory. Falling through to CreateFile would surface a
+		// confusing GitHub error, so reject it explicitly.
+		return fmt.Errorf("%s: path %q is a directory, expected a file", name, change.FilePath)
+	case err == nil && existing.GetSHA() != "":
+		opts.SHA = gh.Ptr(existing.GetSHA())
+		if _, _, err = t.client.Repositories.UpdateFile(ctx, t.owner, t.repo, change.FilePath, opts); err != nil {
+			return fmt.Errorf("%s: update file %q: %w", name, change.FilePath, err)
+		}
+	case err == nil || isNotFound(err):
+		if _, _, err = t.client.Repositories.CreateFile(ctx, t.owner, t.repo, change.FilePath, opts); err != nil {
+			return fmt.Errorf("%s: create file %q: %w", name, change.FilePath, err)
+		}
+	default:
+		return fmt.Errorf("%s: read file %q: %w", name, change.FilePath, err)
+	}
+	return nil
+}
+
+// branchName derives a safe, namespaced branch name from the change. It uses
+// the target file path as the discriminator so repeated deliveries for the same
+// file reuse a branch (the already-exists path handles that gracefully).
+func branchName(change scm.Change) string {
+	return branchPrefix + slugify(change.FilePath)
+}
+
+// commitMessage builds a one-line commit subject from the change description,
+// falling back to the file path.
+func commitMessage(change scm.Change) string {
+	subject := firstLine(change.Description)
+	if subject == "" {
+		subject = "update " + change.FilePath
+	}
+	return "fix: " + subject
+}
+
+// prTitle builds a PR title from the severity and change description.
+func prTitle(change scm.Change) string {
+	subject := firstLine(change.Description)
+	if subject == "" {
+		subject = "remediate " + change.FilePath
+	}
+	return fmt.Sprintf("[%s] %s", severityLabel(change.Severity), subject)
+}
+
+// severityLabel renders a Severity for a PR title, defaulting to "remediation"
+// for the unknown level.
+func severityLabel(s domain.Severity) string {
+	if s == domain.SeverityUnknown {
+		return "remediation"
+	}
+	return s.String()
+}
+
+// firstLine returns the first non-empty trimmed line of s.
+func firstLine(s string) string {
+	for line := range strings.SplitSeq(s, "\n") {
+		if t := strings.TrimSpace(line); t != "" {
+			return t
+		}
+	}
+	return ""
+}
+
+// isAlreadyExists reports whether err is a GitHub 422 (reference already exists).
+func isAlreadyExists(err error) bool {
+	return hasStatus(err, http.StatusUnprocessableEntity)
+}
+
+// isNotFound reports whether err is a GitHub 404.
+func isNotFound(err error) bool {
+	return hasStatus(err, http.StatusNotFound)
+}
+
+// hasStatus reports whether err is a *github.ErrorResponse with the given HTTP
+// status code.
+func hasStatus(err error, code int) bool {
+	var ghErr *gh.ErrorResponse
+	if errors.As(err, &ghErr) && ghErr.Response != nil {
+		return ghErr.Response.StatusCode == code
+	}
+	return false
+}
+
+// slugSeparators matches any run of characters that are not safe in a git
+// branch component; each run collapses to a single hyphen.
+var slugSeparators = regexp.MustCompile(`[^a-zA-Z0-9._-]+`)
+
+// slugify turns an arbitrary file path into a single safe branch component,
+// e.g. "src/api/handler.go" -> "src-api-handler.go".
+func slugify(path string) string {
+	s := slugSeparators.ReplaceAllString(path, "-")
+	s = strings.Trim(s, "-")
+	if s == "" {
+		return "change"
+	}
+	return s
+}

--- a/internal/scm/github/github_test.go
+++ b/internal/scm/github/github_test.go
@@ -1,0 +1,454 @@
+package github
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	gh "github.com/google/go-github/v88/github"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/avivl/cloud-sre-agent/internal/domain"
+	"github.com/avivl/cloud-sre-agent/internal/scm"
+)
+
+const (
+	testOwner = "acme"
+	testRepo  = "widgets"
+	baseSHA   = "abc123def456"
+)
+
+// newTestTarget wires a GitHubTarget at an httptest.Server via the BaseURL seam.
+func newTestTarget(t *testing.T, srv *httptest.Server, base string) *GitHubTarget {
+	t.Helper()
+	target, err := New(Config{
+		Owner:      testOwner,
+		Repo:       testRepo,
+		BaseBranch: base,
+		Token:      "unused-in-tests",
+		BaseURL:    srv.URL + "/",
+		HTTPClient: srv.Client(),
+	})
+	require.NoError(t, err)
+	return target
+}
+
+func decodeBody(t *testing.T, r *http.Request, v any) {
+	t.Helper()
+	body, err := io.ReadAll(r.Body)
+	require.NoError(t, err)
+	require.NoError(t, json.Unmarshal(body, v))
+}
+
+func TestDeliver_HappyPath_NewFile(t *testing.T) {
+	var (
+		createdRefPayload  gh.CreateRef
+		contentPayload     gh.RepositoryContentFileOptions
+		prPayload          gh.NewPullRequest
+		sawCreateFilePUT   bool
+		sawUpdateFilePUT   bool
+		getContentsCount   int
+		createBranchCalled bool
+	)
+
+	mux := http.NewServeMux()
+
+	// (1) GET base ref.
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/git/ref/heads/main",
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, gh.Reference{
+				Ref:    gh.Ptr("refs/heads/main"),
+				Object: &gh.GitObject{SHA: gh.Ptr(baseSHA)},
+			})
+		})
+
+	// (2) POST new branch ref.
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/git/refs",
+		func(w http.ResponseWriter, r *http.Request) {
+			createBranchCalled = true
+			decodeBody(t, r, &createdRefPayload)
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.Reference{Ref: gh.Ptr(createdRefPayload.Ref)})
+		})
+
+	// (3a) GET contents -> 404 (file does not exist yet).
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, _ *http.Request) {
+			getContentsCount++
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(t, w, gh.ErrorResponse{Message: "Not Found"})
+		})
+
+	// (3b) PUT contents -> create or update.
+	mux.HandleFunc("PUT /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, r *http.Request) {
+			decodeBody(t, r, &contentPayload)
+			// Distinguish create vs update by presence of SHA.
+			if contentPayload.SHA != nil {
+				sawUpdateFilePUT = true
+			} else {
+				sawCreateFilePUT = true
+			}
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.RepositoryContentResponse{
+				Content: &gh.RepositoryContent{SHA: gh.Ptr("newblob")},
+			})
+		})
+
+	// (4) POST pulls.
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/pulls",
+		func(w http.ResponseWriter, r *http.Request) {
+			decodeBody(t, r, &prPayload)
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.PullRequest{
+				Number:  gh.Ptr(42),
+				HTMLURL: gh.Ptr("https://github.com/acme/widgets/pull/42"),
+			})
+		})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	target := newTestTarget(t, srv, "main")
+
+	change := scm.Change{
+		FilePath:    "src/api/handler.go",
+		Patch:       "package api\n\nfunc Handler() {}\n",
+		Description: "Fix nil deref in handler\n\nFull explanation here.",
+		Severity:    domain.SeverityCritical,
+	}
+
+	ref, err := target.Deliver(context.Background(), change)
+	require.NoError(t, err)
+
+	// Returned Ref.
+	assert.Equal(t, "42", ref.ID)
+	assert.Equal(t, "https://github.com/acme/widgets/pull/42", ref.URL)
+
+	// Branch shaping.
+	assert.True(t, createBranchCalled)
+	assert.Equal(t, "refs/heads/sre-agent/src-api-handler.go", createdRefPayload.Ref)
+	assert.Equal(t, baseSHA, createdRefPayload.SHA)
+
+	// File content == full patch body, on the new branch, create (no SHA).
+	assert.True(t, sawCreateFilePUT)
+	assert.False(t, sawUpdateFilePUT)
+	assert.Equal(t, 1, getContentsCount)
+	assert.Equal(t, change.Patch, string(contentPayload.Content))
+	require.NotNil(t, contentPayload.Branch)
+	assert.Equal(t, "sre-agent/src-api-handler.go", *contentPayload.Branch)
+	assert.Nil(t, contentPayload.SHA)
+	require.NotNil(t, contentPayload.Message)
+	assert.Contains(t, *contentPayload.Message, "Fix nil deref in handler")
+
+	// PR shaping.
+	require.NotNil(t, prPayload.Head)
+	require.NotNil(t, prPayload.Base)
+	require.NotNil(t, prPayload.Title)
+	require.NotNil(t, prPayload.Body)
+	assert.Equal(t, "sre-agent/src-api-handler.go", *prPayload.Head)
+	assert.Equal(t, "main", *prPayload.Base)
+	assert.Contains(t, *prPayload.Title, "critical")
+	assert.Contains(t, *prPayload.Title, "Fix nil deref in handler")
+	assert.Equal(t, change.Description, *prPayload.Body)
+}
+
+func TestDeliver_UpdatesExistingFile(t *testing.T) {
+	var contentPayload gh.RepositoryContentFileOptions
+	sawUpdate := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/git/ref/heads/main",
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, gh.Reference{Object: &gh.GitObject{SHA: gh.Ptr(baseSHA)}})
+		})
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/git/refs",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.Reference{})
+		})
+	// File already exists: return its blob SHA.
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, gh.RepositoryContent{
+				Type: gh.Ptr("file"),
+				SHA:  gh.Ptr("existingblob"),
+				Path: gh.Ptr("README.md"),
+			})
+		})
+	mux.HandleFunc("PUT /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, r *http.Request) {
+			sawUpdate = true
+			decodeBody(t, r, &contentPayload)
+			w.WriteHeader(http.StatusOK)
+			writeJSON(t, w, gh.RepositoryContentResponse{})
+		})
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/pulls",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.PullRequest{
+				Number:  gh.Ptr(7),
+				HTMLURL: gh.Ptr("https://github.com/acme/widgets/pull/7"),
+			})
+		})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	target := newTestTarget(t, srv, "") // empty -> defaults to main
+
+	ref, err := target.Deliver(context.Background(), scm.Change{
+		FilePath:    "README.md",
+		Patch:       "# Widgets\n",
+		Description: "Update readme",
+		Severity:    domain.SeverityInfo,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "7", ref.ID)
+	assert.True(t, sawUpdate)
+	require.NotNil(t, contentPayload.SHA)
+	assert.Equal(t, "existingblob", *contentPayload.SHA, "update must carry current blob SHA")
+	assert.Equal(t, "# Widgets\n", string(contentPayload.Content))
+}
+
+func TestDeliver_AlreadyExistsBranch_Tolerated(t *testing.T) {
+	prOpened := false
+	var forceUpdatePayload gh.UpdateRef
+	forceUpdateCalled := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/git/ref/heads/main",
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, gh.Reference{Object: &gh.GitObject{SHA: gh.Ptr(baseSHA)}})
+		})
+	// Branch already exists -> 422.
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/git/refs",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			writeJSON(t, w, gh.ErrorResponse{Message: "Reference already exists"})
+		})
+	// A lingering branch must be force-reset to the freshly-resolved base SHA.
+	mux.HandleFunc("PATCH /api/v3/repos/"+testOwner+"/"+testRepo+"/git/refs/heads/sre-agent/main.go",
+		func(w http.ResponseWriter, r *http.Request) {
+			forceUpdateCalled = true
+			decodeBody(t, r, &forceUpdatePayload)
+			writeJSON(t, w, gh.Reference{Object: &gh.GitObject{SHA: gh.Ptr(baseSHA)}})
+		})
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(t, w, gh.ErrorResponse{Message: "Not Found"})
+		})
+	mux.HandleFunc("PUT /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.RepositoryContentResponse{})
+		})
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/pulls",
+		func(w http.ResponseWriter, _ *http.Request) {
+			prOpened = true
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.PullRequest{
+				Number:  gh.Ptr(99),
+				HTMLURL: gh.Ptr("https://github.com/acme/widgets/pull/99"),
+			})
+		})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	target := newTestTarget(t, srv, "main")
+
+	ref, err := target.Deliver(context.Background(), scm.Change{
+		FilePath:    "main.go",
+		Patch:       "package main\n",
+		Description: "retry delivery",
+		Severity:    domain.SeverityError,
+	})
+	require.NoError(t, err, "an already-exists branch must not fail Deliver")
+	assert.Equal(t, "99", ref.ID)
+	assert.True(t, prOpened)
+	// FIX 3: the stale branch is force-reset to the current base SHA.
+	assert.True(t, forceUpdateCalled, "lingering branch must be force-updated to base")
+	assert.Equal(t, baseSHA, forceUpdatePayload.SHA)
+	require.NotNil(t, forceUpdatePayload.Force)
+	assert.True(t, *forceUpdatePayload.Force, "branch reset must be a force update")
+}
+
+func TestDeliver_DuplicatePR_ResolvesExisting(t *testing.T) {
+	listCalled := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/git/ref/heads/main",
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, gh.Reference{Object: &gh.GitObject{SHA: gh.Ptr(baseSHA)}})
+		})
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/git/refs",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.Reference{})
+		})
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(t, w, gh.ErrorResponse{Message: "Not Found"})
+		})
+	mux.HandleFunc("PUT /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.RepositoryContentResponse{})
+		})
+	// Create the PR -> 422 "already exists".
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/pulls",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			writeJSON(t, w, gh.ErrorResponse{Message: "A pull request already exists for acme:sre-agent/main.go."})
+		})
+	// List the open PR for the head branch -> resolve the existing one.
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/pulls",
+		func(w http.ResponseWriter, r *http.Request) {
+			listCalled = true
+			assert.Equal(t, "open", r.URL.Query().Get("state"))
+			assert.Equal(t, testOwner+":sre-agent/main.go", r.URL.Query().Get("head"))
+			writeJSON(t, w, []gh.PullRequest{{
+				Number:  gh.Ptr(123),
+				HTMLURL: gh.Ptr("https://github.com/acme/widgets/pull/123"),
+			}})
+		})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	target := newTestTarget(t, srv, "main")
+
+	ref, err := target.Deliver(context.Background(), scm.Change{
+		FilePath:    "main.go",
+		Patch:       "package main\n",
+		Description: "retry delivery",
+		Severity:    domain.SeverityError,
+	})
+	require.NoError(t, err, "a duplicate PR must not fail Deliver")
+	assert.True(t, listCalled, "must list existing PRs after a 422 on create")
+	assert.Equal(t, "123", ref.ID)
+	assert.Equal(t, "https://github.com/acme/widgets/pull/123", ref.URL)
+}
+
+func TestDeliver_PathIsDirectory_Errors(t *testing.T) {
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/git/ref/heads/main",
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, gh.Reference{Object: &gh.GitObject{SHA: gh.Ptr(baseSHA)}})
+		})
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/git/refs",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			writeJSON(t, w, gh.Reference{})
+		})
+	// GetContents on a directory returns a JSON array (no error, but no file
+	// entry): go-github yields fileContent==nil.
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/contents/",
+		func(w http.ResponseWriter, _ *http.Request) {
+			writeJSON(t, w, []gh.RepositoryContent{
+				{Type: gh.Ptr("file"), Name: gh.Ptr("a.go"), Path: gh.Ptr("src/a.go")},
+			})
+		})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	target := newTestTarget(t, srv, "main")
+
+	_, err := target.Deliver(context.Background(), scm.Change{
+		FilePath:    "src",
+		Patch:       "package main\n",
+		Description: "x",
+		Severity:    domain.SeverityCritical,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "is a directory")
+}
+
+func TestDeliver_BaseRefNotFound(t *testing.T) {
+	pullsCalled := false
+
+	mux := http.NewServeMux()
+	mux.HandleFunc("GET /api/v3/repos/"+testOwner+"/"+testRepo+"/git/ref/heads/main",
+		func(w http.ResponseWriter, _ *http.Request) {
+			w.WriteHeader(http.StatusNotFound)
+			writeJSON(t, w, gh.ErrorResponse{Message: "Not Found"})
+		})
+	mux.HandleFunc("POST /api/v3/repos/"+testOwner+"/"+testRepo+"/pulls",
+		func(w http.ResponseWriter, _ *http.Request) {
+			pullsCalled = true
+			w.WriteHeader(http.StatusCreated)
+		})
+
+	srv := httptest.NewServer(mux)
+	defer srv.Close()
+
+	target := newTestTarget(t, srv, "main")
+
+	_, err := target.Deliver(context.Background(), scm.Change{
+		FilePath:    "main.go",
+		Patch:       "package main\n",
+		Description: "x",
+		Severity:    domain.SeverityCritical,
+	})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "get base ref")
+	assert.False(t, pullsCalled, "must not open a PR when the base ref is missing")
+}
+
+// bareClient builds a default *github.Client for tests that never hit the network.
+func bareClient(t *testing.T) *gh.Client {
+	t.Helper()
+	c, err := gh.NewClient()
+	require.NoError(t, err)
+	return c
+}
+
+func TestDeliver_ValidatesInput(t *testing.T) {
+	// No server contact needed: validation happens before any HTTP call.
+	target := NewWithClient(bareClient(t), testOwner, testRepo, "main")
+
+	_, err := target.Deliver(context.Background(), scm.Change{Patch: "body"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "FilePath is required")
+
+	_, err = target.Deliver(context.Background(), scm.Change{FilePath: "a.go"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Patch is empty")
+}
+
+func TestName(t *testing.T) {
+	assert.Equal(t, "github", NewWithClient(bareClient(t), testOwner, testRepo, "main").Name())
+}
+
+func TestNew_RequiresOwnerAndRepo(t *testing.T) {
+	_, err := New(Config{Repo: "r"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Owner is required")
+
+	_, err = New(Config{Owner: "o"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Repo is required")
+}
+
+// TestTarget_ImplementsPRTarget is a compile-time assertion.
+func TestTarget_ImplementsPRTarget(_ *testing.T) {
+	var _ scm.PRTarget = (*GitHubTarget)(nil)
+}
+
+func writeJSON(t *testing.T, w http.ResponseWriter, v any) {
+	t.Helper()
+	w.Header().Set("Content-Type", "application/json")
+	body, err := json.Marshal(v)
+	require.NoError(t, err)
+	_, err = w.Write(body)
+	require.NoError(t, err)
+}

--- a/internal/validate/validate.go
+++ b/internal/validate/validate.go
@@ -1,0 +1,226 @@
+// Package validate implements the pipeline.CodeValidator port with a local,
+// toolchain-backed validator. It gates LLM-generated patches before delivery:
+// for Go it parses the patch for syntax, checks gofmt formatting, and runs a
+// best-effort `go vet` inside a throwaway temp module. Unsupported languages
+// are skipped (never an error). Patch contents are treated as potentially
+// sensitive and are never logged.
+package validate
+
+import (
+	"context"
+	"fmt"
+	"go/parser"
+	"go/token"
+	"log/slog"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+
+	"github.com/avivl/cloud-sre-agent/internal/pipeline"
+)
+
+// langGo is the language identifier this validator validates (case-insensitive).
+const langGo = "go"
+
+// patchFileName is the name the patch is written under inside the temp module.
+// It is fixed (not derived from the patch) so nothing patch-controlled reaches
+// the filesystem path.
+const patchFileName = "patch.go"
+
+// dirPerm and filePerm are the permissions for the temp module and patch file.
+const (
+	dirPerm  os.FileMode = 0o700
+	filePerm os.FileMode = 0o600
+)
+
+// LocalValidator validates patches with the local Go toolchain. The zero value
+// is usable (it logs to slog.Default); prefer constructing with New.
+type LocalValidator struct {
+	logger *slog.Logger
+}
+
+// Option configures a LocalValidator.
+type Option func(*LocalValidator)
+
+// WithLogger sets the structured logger. A nil logger is ignored. The logger
+// is used only for non-sensitive diagnostics; patch contents are never logged.
+func WithLogger(l *slog.Logger) Option {
+	return func(v *LocalValidator) {
+		if l != nil {
+			v.logger = l
+		}
+	}
+}
+
+// New returns a LocalValidator. Without WithLogger it logs to slog.Default.
+func New(opts ...Option) *LocalValidator {
+	v := &LocalValidator{logger: slog.Default()}
+	for _, opt := range opts {
+		opt(v)
+	}
+	return v
+}
+
+// Compile-time assertion that LocalValidator satisfies the port.
+var _ pipeline.CodeValidator = (*LocalValidator)(nil)
+
+// Validate checks patch for the given lang. For "go" (case-insensitive) it runs
+// a syntax gate, a gofmt formatting gate, and a best-effort go vet, collecting
+// human-readable diagnostics. OK is true only if every gate passes. Other
+// languages are skipped with OK=true and an informational diagnostic; an
+// unsupported language is never an error. Validate never returns the patch body
+// in its error or diagnostics beyond the toolchain's own messages.
+func (v *LocalValidator) Validate(ctx context.Context, patch string, lang string) (pipeline.ValidationResult, error) {
+	if !strings.EqualFold(strings.TrimSpace(lang), langGo) {
+		return pipeline.ValidationResult{
+			OK:          true,
+			Diagnostics: []string{fmt.Sprintf("validation skipped: unsupported language %q", lang)},
+		}, nil
+	}
+	return v.validateGo(ctx, patch)
+}
+
+// validateGo runs the Go gates. It returns an error only for environment
+// failures (cannot create temp dir / write file); gate failures are reported
+// as diagnostics with OK=false.
+func (v *LocalValidator) validateGo(ctx context.Context, patch string) (pipeline.ValidationResult, error) {
+	var diags []string
+
+	// Syntax gate: parse with go/parser. This is fast, deterministic, and free
+	// of any toolchain/network race. A parse error is the primary signal that a
+	// patch is broken (e.g. a missing brace).
+	fset := token.NewFileSet()
+	if _, err := parser.ParseFile(fset, patchFileName, patch, parser.AllErrors); err != nil {
+		// err already carries position-prefixed messages; it does not echo the
+		// full patch body.
+		diags = append(diags, "syntax: "+err.Error())
+		// Syntax errors make gofmt/vet output redundant and noisy; stop here.
+		v.logger.DebugContext(ctx, "go patch failed syntax gate", "gate", "syntax")
+		return pipeline.ValidationResult{OK: false, Diagnostics: diags}, nil
+	}
+
+	// Set up a minimal temp module so gofmt and go vet have a real file/package.
+	dir, err := os.MkdirTemp("", "sre-validate-*")
+	if err != nil {
+		return pipeline.ValidationResult{}, fmt.Errorf("validate: create temp dir: %w", err)
+	}
+	defer func() {
+		if rmErr := os.RemoveAll(dir); rmErr != nil {
+			v.logger.WarnContext(ctx, "failed to clean up validation temp dir", "dir", dir)
+		}
+	}()
+
+	patchPath := filepath.Join(dir, patchFileName)
+	if err := os.WriteFile(patchPath, []byte(patch), filePerm); err != nil {
+		return pipeline.ValidationResult{}, fmt.Errorf("validate: write patch file: %w", err)
+	}
+
+	// constrainedEnv sandboxes every go subcommand below; see sandboxEnv.
+	env := sandboxEnv(dir)
+
+	// Formatting gate: gofmt -l prints the file name if it is NOT gofmt-formatted.
+	// This is a pre-delivery gate: if the gate cannot be INVOKED (PATH/env
+	// problem) we fail closed (OK=false), distinguishing it from a clean run.
+	if out, gErr := runGofmt(ctx, env, patchPath); gErr != nil {
+		diags = append(diags, "gofmt: gate could not run ("+gErr.Error()+")")
+		v.logger.WarnContext(ctx, "gofmt invocation failed", "gate", "gofmt")
+	} else if strings.TrimSpace(out) != "" {
+		diags = append(diags, "format: file is not gofmt-formatted")
+	}
+
+	// Build/vet gate: a minimal module lets `go vet` type-check and report
+	// suspicious constructs. go vet implies a build, so it doubles as the build
+	// gate for a single-file package. Inability to run the gate (e.g. `go mod
+	// init` cannot be invoked) fails closed rather than open.
+	if vetDiags, vErr := v.runVet(ctx, env, dir); vErr != nil {
+		diags = append(diags, "vet: gate could not run ("+vErr.Error()+")")
+		v.logger.WarnContext(ctx, "go vet invocation failed", "gate", "vet")
+	} else {
+		diags = append(diags, vetDiags...)
+	}
+
+	ok := len(diags) == 0
+	if !ok {
+		v.logger.DebugContext(ctx, "go patch failed validation", "diagnostic_count", len(diags))
+	}
+	return pipeline.ValidationResult{OK: ok, Diagnostics: diags}, nil
+}
+
+// sandboxEnv builds the MINIMAL environment for go subcommands run over
+// untrusted, LLM-generated code. Compiling such code is an arbitrary-code-
+// execution surface (cgo, module fetches, toolchain auto-download), so this is
+// the ACE-hardening boundary: the subprocess gets only what the toolchain needs
+// and never inherits the parent environment (notably no GITHUB_TOKEN or other
+// secrets). dir doubles as a throwaway HOME/GOPATH/GOCACHE so nothing touches
+// the real user environment.
+//
+// The flags pin the toolchain shut: GOPROXY=off (no network module fetches),
+// GOTOOLCHAIN=local (no toolchain auto-download), CGO_ENABLED=0 (no C compiler,
+// so an `import "C"` patch fails closed instead of invoking cgo), and checksum
+// DB lookups disabled.
+func sandboxEnv(dir string) []string {
+	path := os.Getenv("PATH") // needed to locate the go/gofmt binaries
+	return []string{
+		"PATH=" + path,
+		"HOME=" + dir,
+		"GOPATH=" + filepath.Join(dir, "gopath"),
+		"GOCACHE=" + filepath.Join(dir, "gocache"),
+		"GOFLAGS=-mod=mod",
+		"GOPROXY=off",
+		"GOTOOLCHAIN=local",
+		"CGO_ENABLED=0",
+		"GONOSUMCHECK=1",
+		"GOSUMDB=off",
+	}
+}
+
+// runGofmt runs `gofmt -l <file>` under the constrained sandbox env and returns
+// its stdout. A non-empty stdout means the file is not gofmt-formatted.
+func runGofmt(ctx context.Context, env []string, file string) (string, error) {
+	cmd := exec.CommandContext(ctx, "gofmt", "-l", file)
+	cmd.Env = env
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+// runVet initializes a throwaway module in dir and runs `go vet` over it, both
+// under the constrained sandbox env (the ACE-hardening boundary for untrusted
+// LLM-generated code). It returns one diagnostic per problem reported by the
+// toolchain. An error is returned only if `go mod init` itself cannot run
+// (environmental); vet findings are returned as diagnostics, not errors.
+func (v *LocalValidator) runVet(ctx context.Context, env []string, dir string) ([]string, error) {
+	initCmd := exec.CommandContext(ctx, "go", "mod", "init", "srevalidate")
+	initCmd.Dir = dir
+	initCmd.Env = env
+	if out, err := initCmd.CombinedOutput(); err != nil {
+		return nil, fmt.Errorf("go mod init: %w: %s", err, strings.TrimSpace(string(out)))
+	}
+
+	vetCmd := exec.CommandContext(ctx, "go", "vet", "./...")
+	vetCmd.Dir = dir
+	vetCmd.Env = env
+	out, err := vetCmd.CombinedOutput()
+	if err == nil {
+		return nil, nil
+	}
+	// go vet writes findings (and build errors) to stderr; CombinedOutput
+	// captures them. Each non-empty line is a diagnostic. The output references
+	// the fixed patch.go path, not the patch body.
+	var diags []string
+	for _, line := range strings.Split(strings.TrimSpace(string(out)), "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" || strings.HasPrefix(line, "#") {
+			continue
+		}
+		diags = append(diags, "vet: "+line)
+	}
+	if len(diags) == 0 {
+		// Non-zero exit with no parseable output: report the raw failure.
+		diags = append(diags, "vet: failed ("+err.Error()+")")
+	}
+	return diags, nil
+}

--- a/internal/validate/validate_test.go
+++ b/internal/validate/validate_test.go
@@ -1,0 +1,152 @@
+package validate
+
+import (
+	"context"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/avivl/cloud-sre-agent/internal/pipeline"
+)
+
+// Compile-time assertion mirrored in tests for documentation.
+var _ pipeline.CodeValidator = (*LocalValidator)(nil)
+
+// validGo is a syntactically correct, gofmt-formatted, vet-clean snippet.
+const validGo = `package main
+
+import "fmt"
+
+func main() {
+	fmt.Println("hello")
+}
+`
+
+// brokenGo is missing the closing brace of main, so go/parser rejects it.
+const brokenGo = `package main
+
+func main() {
+	x := 1
+	_ = x
+`
+
+func TestValidate_ValidGo_OK(t *testing.T) {
+	v := New()
+	res, err := v.Validate(context.Background(), validGo, "go")
+	require.NoError(t, err)
+	assert.True(t, res.OK, "valid Go should pass: %v", res.Diagnostics)
+	assert.Empty(t, res.Diagnostics)
+}
+
+func TestValidate_BrokenGo_NotOK(t *testing.T) {
+	v := New()
+	res, err := v.Validate(context.Background(), brokenGo, "go")
+	require.NoError(t, err)
+	assert.False(t, res.OK)
+	require.NotEmpty(t, res.Diagnostics)
+	assert.True(t,
+		strings.Contains(res.Diagnostics[0], "syntax"),
+		"expected a syntax diagnostic, got %v", res.Diagnostics)
+}
+
+func TestValidate_CaseInsensitiveLang(t *testing.T) {
+	v := New()
+	res, err := v.Validate(context.Background(), validGo, "GO")
+	require.NoError(t, err)
+	assert.True(t, res.OK, "uppercase GO should be treated as go: %v", res.Diagnostics)
+	assert.Empty(t, res.Diagnostics)
+}
+
+func TestValidate_UnsupportedLang_SkippedOK(t *testing.T) {
+	v := New()
+	res, err := v.Validate(context.Background(), "print('hi')", "python")
+	require.NoError(t, err)
+	assert.True(t, res.OK)
+	require.Len(t, res.Diagnostics, 1)
+	assert.Contains(t, res.Diagnostics[0], "validation skipped")
+	assert.Contains(t, res.Diagnostics[0], "python")
+}
+
+func TestValidate_UnformattedGo_NotOK(t *testing.T) {
+	// Syntactically valid but not gofmt-formatted (leading spaces, no tabs).
+	unformatted := "package main\n\nfunc main() {\n  x := 1\n  _ = x\n}\n"
+	v := New()
+	res, err := v.Validate(context.Background(), unformatted, "go")
+	require.NoError(t, err)
+	assert.False(t, res.OK)
+	found := false
+	for _, d := range res.Diagnostics {
+		if strings.Contains(d, "format") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a format diagnostic, got %v", res.Diagnostics)
+}
+
+func TestValidate_CgoPatch_FailsClosedNoExec(t *testing.T) {
+	// A patch that pulls in cgo. Under the sandbox env CGO_ENABLED=0, so the
+	// toolchain must refuse to build it (OK=false) rather than invoking a C
+	// compiler on untrusted code. The malloc reference would not link if cgo
+	// were ever enabled; with cgo disabled the build fails first.
+	cgoPatch := `package main
+
+// #include <stdlib.h>
+import "C"
+
+func main() {
+	C.malloc(1)
+}
+`
+	v := New()
+	res, err := v.Validate(context.Background(), cgoPatch, "go")
+	require.NoError(t, err)
+	assert.False(t, res.OK, "cgo patch must fail closed under CGO_ENABLED=0")
+	require.NotEmpty(t, res.Diagnostics)
+}
+
+func TestRunGofmt_GateCannotRun_FailsClosed(t *testing.T) {
+	// When the gate cannot be INVOKED (here: a cancelled context kills the
+	// subprocess before it can run), the helper surfaces an error. validateGo
+	// turns that into an OK=false "gate could not run" diagnostic — a
+	// pre-delivery gate fails closed, never silently passes.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := runGofmt(ctx, sandboxEnv(t.TempDir()), filepath.Join(t.TempDir(), patchFileName))
+	require.Error(t, err, "gofmt gate must report an error when it cannot be invoked")
+}
+
+func TestRunVet_GateCannotRun_FailsClosed(t *testing.T) {
+	// A cancelled context prevents `go mod init` from running; runVet must
+	// return an error (recorded as an OK=false "gate could not run" diagnostic),
+	// not a nil error that would let the patch through.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	_, err := New().runVet(ctx, sandboxEnv(t.TempDir()), t.TempDir())
+	require.Error(t, err, "vet gate must report an error when it cannot be invoked")
+}
+
+func TestValidate_VetCatchesBadCode(t *testing.T) {
+	// Syntactically valid and gofmt-formatted, but vet flags the Printf verb.
+	vetBad := `package main
+
+import "fmt"
+
+func main() {
+	fmt.Printf("%d", "not a number")
+}
+`
+	v := New()
+	res, err := v.Validate(context.Background(), vetBad, "go")
+	require.NoError(t, err)
+	assert.False(t, res.OK)
+	found := false
+	for _, d := range res.Diagnostics {
+		if strings.Contains(d, "vet") {
+			found = true
+		}
+	}
+	assert.True(t, found, "expected a vet diagnostic, got %v", res.Diagnostics)
+}


### PR DESCRIPTION
## What

The agent now opens a real **GitHub pull request** with the remediation patch, and **validates** LLM-generated Go patches before delivery. Builds on #17 (MVP), #18 (GCP ingest).

## Changes

- **`internal/scm/github`** — `GitHubTarget` (implements `scm.PRTarget`) via `go-github/v88`: resolve base-branch SHA → create (or force-update) a `sre-agent/<file>` branch → commit the file via the Contents API → open a PR (or resolve the existing one on re-run). No clone, stateless — fits the worker pool. Hermetic tests via `httptest`.
- **`internal/validate`** — `LocalValidator` (implements `pipeline.CodeValidator`): writes the patch to a temp dir and runs syntax/`gofmt`/`go vet` for Go (OK-skips other langs), failing closed if a gate can't run.
- **`internal/config` + `cmd/sre-agent`** — `target` (`local`|`github`) and `validator` (`none`|`local`) selectors; GitHub token read from env at wire time, never stored or logged.

## Security (this PR's headline)

Validating LLM-generated code means *compiling untrusted input*. Every `go` subcommand in the validator runs in a **sandboxed env**: no inherited environment (so `GITHUB_TOKEN` and other secrets never reach it), and the toolchain pinned shut — `GOPROXY=off` (no module fetches), `GOTOOLCHAIN=local` (no toolchain download), `CGO_ENABLED=0` (no C compiler). A patch with `import "C"` fails closed and executes nothing (tested).

## Review gates (run pre-PR)

- **Code review:** found a **critical** ACE surface in the validator (now sandboxed, above) plus correctness fixes — duplicate-PR 422 resolved to the existing PR, stale branch force-updated to fresh base SHA, directory-path guard.
- **HIPAA review:** **no must-fix.** Full provenance traced — everything reaching GitHub (branch name, commit, file, PR title/body) derives from already-sanitized LLM output; raw log/incident content cannot leak to GitHub. Token never logged. Added `error_detail`/`error_type` to the obs redactor as a backstop.

## Verification

- `go build`/`vet` clean, `golangci-lint` **0 issues**, `go test -race` green, `./internal/...` coverage **88.9%**
- **Re-run with ADC forced off** (CI condition) — all hermetic (httptest / no ambient GitHub or GCP creds)
- Linux static cross-compile OK; new test files swept for scannable secret literals (none)

## Not in this PR

GitLab adapter (next fast-follow, same port). Cloud Run Sandbox validator (preview — the local validator fills the port). Unified-diff/multi-file patches (full-file body only). Secret Manager token loading (env for now).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
